### PR TITLE
fix typo req.user.sale --> req.user.salt

### DIFF
--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -39,8 +39,8 @@ exports.updateUser = function(req, res) {
   req.user.lastName = userUpdates.lastName;
   req.user.username = userUpdates.username;
   if(userUpdates.password && userUpdates.password.length > 0) {
-    req.user.sale = encrypt.createSalt();
-    req.user.hashed_pwd = encrypt.hashPwd(req.user.sale, userUpdates.password);
+    req.user.salt = encrypt.createSalt();
+    req.user.hashed_pwd = encrypt.hashPwd(req.user.salt, userUpdates.password);
   }
   req.user.save(function(err) {
     if(err) { res.status(400); return res.send({reason:err.toString()});}


### PR DESCRIPTION
Working through this awesome pluralsight course, I found a small
typo--req.user.sale should be req.user.salt in the updateUser method
of the user controller.  This will add an unwanted property on the
req.user object, but more importantly, will update the password hash
with the wrong salt.  This has the potential to create quite of bit
of frustration debugging.

Thanks for the great courses, Joe!